### PR TITLE
chore: drop Python 3.9 support

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/master-linters.yml
+++ b/.github/workflows/master-linters.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,3 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed linters problems (logging)
 - Bumped requirements & badges
+
+## [0.0.12] - 2026-07-07
+
+### Changed
+- Dropped Python 3.9 support: pinned dependencies (aiohttp, requests, urllib3) already require Python >=3.10, so `python_requires`/CI matrix now start at 3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "leonardo_api"
-version = "0.0.11"
+version = "0.0.12"
 authors = [
   { name="Iliya Vereshchagin", email="i.vereshchagin@gmail.com" },
 ]
@@ -15,7 +15,7 @@ keywords = ["leonardo", "ai", "image generation", "artificial intelligence", "ap
 description = "Leonardo.ai Python API"
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     'requests',
     'aiohttp',
@@ -29,7 +29,6 @@ dependencies = [
     'frozenlist'
 ]
 classifiers = [
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = leonardo_api
-version = attr: leonardo_api.0.0.11
+version = attr: leonardo_api.0.0.12
 author = Iliya Vereshchagin
 author_email = i.vereshchagin@gmail.com
 maintainer = Iliya Vereshchagin
@@ -11,9 +11,8 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 keywords = leonardo, leonardo.ai, image generation, stablediffusion, api, llm, ai, artificial intelligence
 license = MIT License
-python_requires = >=3.9
+python_requires = >=3.10
 classifiers =
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12


### PR DESCRIPTION
## Summary
- Pinned dependencies in `requirements.txt` (aiohttp==3.14.1, requests==2.34.2, urllib3==2.7.0) already require Python >=3.10 — installing on 3.9 currently fails dependency resolution.
- Raise `requires-python` (pyproject.toml) / `python_requires` (setup.cfg) to `>=3.10` and drop the `3.9` classifier.
- Drop `3.9` from both CI matrices (`linters.yml`, `master-linters.yml`), keeping 3.10–3.13.
- Bump package version to 0.0.12 and add a CHANGELOG entry.

Verified locally in Docker that `pip install -r requirements.txt` resolves on 3.10/3.11/3.12/3.13 but fails on 3.9 (no matching aiohttp distribution).

## Test plan
- [x] `pip install --dry-run -r requirements.txt` succeeds on Python 3.10, 3.11, 3.12, 3.13 (Docker)
- [x] Same command fails on Python 3.9 (confirms it was already broken before this change)
- [x] CI (Linters-PR) green on this PR