### PR TITLE
chore: add Python 3.14 support

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/master-linters.yml
+++ b/.github/workflows/master-linters.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed Black formatting compliance (missing blank line after module docstring) in `__init__.py`, `src/__init__.py`, `src/__main__.py`, `src/leonardo_api/__init__.py`; this was failing the master `Linters` workflow (pre-existing, unrelated to Python version support)
+
+## [0.0.14] - 2026-07-07
+
+### Added
+- Added Python 3.14 support: verified dependency install and imports on 3.14, added it to `classifiers` and both CI matrices

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "leonardo_api"
-version = "0.0.13"
+version = "0.0.14"
 authors = [
   { name="Iliya Vereshchagin", email="i.vereshchagin@gmail.com" },
 ]
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Intended Audience :: Developers",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = leonardo_api
-version = attr: leonardo_api.0.0.13
+version = attr: leonardo_api.0.0.14
 author = Iliya Vereshchagin
 author_email = i.vereshchagin@gmail.com
 maintainer = Iliya Vereshchagin
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Operating System :: OS Independent
     Intended Audience :: Developers
     Intended Audience :: Information Technology


### PR DESCRIPTION
## Summary
- Verified in Docker that all pinned dependencies (`requirements.txt`) install and import cleanly on Python 3.14 (`pip install` + import smoke test, no dry-run only).
- Added `Programming Language :: Python :: 3.14` classifier to `pyproject.toml` and `setup.cfg`.
- Added `"3.14"` to both CI matrices (`linters.yml`, `master-linters.yml`).
- Bumped version to 0.0.13 and added a CHANGELOG entry.

Builds on top of #119 (Python 3.9 drop), which is already merged into master.

## Test plan
- [x] `pip install -r requirements.txt` + import smoke test succeeds on Python 3.14 (Docker)
- [ ] CI (Linters-PR) green on all 5 matrix versions (3.10–3.14) for this PR