### PR TITLE
fix: restore Black formatting compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,3 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Dropped Python 3.9 support: pinned dependencies (aiohttp, requests, urllib3) already require Python >=3.10, so `python_requires`/CI matrix now start at 3.10
+
+## [0.0.13] - 2026-07-07
+
+### Fixed
+- Fixed Black formatting compliance (missing blank line after module docstring) in `__init__.py`, `src/__init__.py`, `src/__main__.py`, `src/leonardo_api/__init__.py`; this was failing the master `Linters` workflow (pre-existing, unrelated to Python version support)

--- a/__init__.py
+++ b/__init__.py
@@ -10,6 +10,7 @@ Last Modified: 15.10.2023
 Description:
 This file contains module init
 """
+
 from .src.leonardo_api.leonardo_async import Leonardo as LeonardoAsync  # pylint: disable=unused-import
 from .src.leonardo_api.leonardo_sync import Leonardo  # pylint: disable=unused-import
 from .src.leonardo_api.models import platform_models, custom_models, nsfw_models  # pylint: disable=unused-import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "leonardo_api"
-version = "0.0.12"
+version = "0.0.13"
 authors = [
   { name="Iliya Vereshchagin", email="i.vereshchagin@gmail.com" },
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = leonardo_api
-version = attr: leonardo_api.0.0.12
+version = attr: leonardo_api.0.0.13
 author = Iliya Vereshchagin
 author_email = i.vereshchagin@gmail.com
 maintainer = Iliya Vereshchagin

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,6 +10,7 @@ Last Modified: 15.10.2023
 Description:
 This file contains module init
 """
+
 from .leonardo_api.leonardo_async import Leonardo as LeonardoAsync
 from .leonardo_api.leonardo_sync import Leonardo
 from .leonardo_api.models import platform_models, custom_models, nsfw_models

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -10,6 +10,7 @@ Last Modified: 15.10.2023
 Description:
 This file contains module main init
 """
+
 from .leonardo_api.leonardo_async import Leonardo as LeonardoAsync  # pylint: disable=unused-import
 from .leonardo_api.leonardo_sync import Leonardo  # pylint: disable=unused-import
 from .leonardo_api.models import platform_models, custom_models, nsfw_models  # pylint: disable=unused-import

--- a/src/leonardo_api/__init__.py
+++ b/src/leonardo_api/__init__.py
@@ -10,6 +10,7 @@ Last Modified: 15.10.2023
 Description:
 This file contains module init
 """
+
 from .leonardo_async import Leonardo as LeonardoAsync
 from .leonardo_sync import Leonardo
 from .models import platform_models, custom_models, nsfw_models


### PR DESCRIPTION
## Summary
- The master `Linters` workflow (the one behind the README badge) has been red since before this stream of Python-version changes, unrelated to them: CI installs `black` unpinned, and a newer `black` release requires a blank line between the module docstring and the following imports.
- Added the missing blank line in `__init__.py`, `src/__init__.py`, `src/__main__.py`, `src/leonardo_api/__init__.py` — the 4 files flagged by `black --check`.
- Verified `black --check`, `pylint`, and `mypy` all pass in a Python 3.11 container matching the CI image (flake8 has one pre-existing `WPS204` note in `leonardo_async.py`/`leonardo_sync.py`, unrelated to formatting and not part of the pass/fail gate in the workflow).
- Bumped version to 0.0.13 and added a CHANGELOG entry.

## Test plan
- [x] `black --check` passes locally in a CI-matching container
- [ ] CI (Linters-PR) green on this PR