### PR TITLE
fix: force-refresh stale Python-version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/leonardo-api.svg)](https://badge.fury.io/py/leonardo-api) 
 [![Linters](https://github.com/wwakabobik/leonardo_api/actions/workflows/master-linters.yml/badge.svg?branch=master)](https://github.com/wwakabobik/leonardo_api/actions/workflows/master-linters.yml)
 ![PyPI - License](https://img.shields.io/pypi/l/leonardo-api)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/leonardo-api) 
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/leonardo-api?cacheSeconds=1) 
 [![Downloads](https://static.pepy.tech/badge/leonardo-api)](https://pepy.tech/project/leonardo-api)
 [![Downloads](https://static.pepy.tech/badge/leonardo-api/month)](https://pepy.tech/project/leonardo-api)
 


### PR DESCRIPTION
## Summary
GitHub's camo image proxy (used to render external images in README) had cached a stale copy of the `img.shields.io/pypi/pyversions/leonardo-api` badge showing `3.9 | 3.10 | 3.11 | 3.12 | 3.13`, even though shields.io itself and PyPI already report `3.10 | 3.11 | 3.12 | 3.13 | 3.14` for the just-published 0.0.14 release. Confirmed via direct curl comparison of the shields.io response vs the camo-proxied one.

Appending `?cacheSeconds=1` changes the badge URL, which changes camo's cache key, forcing GitHub to fetch a fresh copy from shields.io on next render.

## Test plan
- [x] Confirmed shields.io already serves correct data (3.10-3.14)
- [x] Confirmed current camo-cached copy on github.com is stale (3.9-3.13)
- [ ] After merge, badge on github.com renders 3.10-3.14